### PR TITLE
Mustache renderer compatible with interface

### DIFF
--- a/src/MustacheRenderer.php
+++ b/src/MustacheRenderer.php
@@ -15,18 +15,116 @@ namespace BabDev\Renderer;
  */
 class MustacheRenderer extends \Mustache_Engine implements RendererInterface
 {
-	/**
-	 * Render and return compiled data.
-	 *
-	 * @param   string  $template  The template file name
-	 * @param   array   $data      The data to pass to the template
-	 *
-	 * @return  string  Compiled data
-	 *
-	 * @since   1.0
-	 */
-	public function render($template, array $data = array())
-	{
-		return parent::render($template, $data);
-	}
+  /**
+  * A constructor method
+  *
+  * @param  array  $config  Configurations
+  *
+  * @return void
+  *
+  * @since   1.0
+  */
+  public function __construct($config = array()) {
+    parent::__construct($config);
+  }
+  
+  /**
+   * Render and return compiled data.
+   *
+   * @param   string  $template  The template file name
+   * @param   array   $data      The data to pass to the template
+   *
+   * @return  string  Compiled data
+   *
+   * @since   1.0
+   */
+  public function render($template, array $data = array())
+  {
+    return parent::render($template, $data);
+  }
+  
+  /**
+   * Add a folder with alias to the renderer
+   *
+   * @param  string  $alias      The folder alias
+   * @param  string  $directory  The folder path
+   * 
+   * @return  boolean  TRUE if the folder is loaded
+   *
+   * @since 1.0
+   */
+  public function addFolder($alias, $directory) 
+  {
+    
+  }
+  
+  /**
+   * Sets file extension for template loader
+   *
+   * @param  string  $extension  Template files extension
+   *
+   * @return  void
+   *
+   * @since 1.0
+   */
+  public function setFileExtension($extension)
+  {
+    
+  }
+  
+  /**
+   * Checks if folder, folder alias, template or template path exists
+   *
+   * @param  string  $path  Full path or part of a path
+   *
+   * @return  boolean  TRUE of the path exists
+   *
+   * @since  1.0
+   */
+  public function pathExists($path)
+  {
+    
+  }
+  
+  /**
+   * Loads data from array into the renderer
+   *
+   * @param  array  $data  Array of variables
+   *
+   * @return boolean  TRUE if data loaded successfully
+   *
+   * @since  1.0
+   */
+  public function setData($data)
+  {
+    
+  }
+  
+  /**
+   * Unloads data from renderer
+   *
+   * @return void
+   *
+   * @since  1.0
+   */
+  public function unsetData()
+  {
+    
+  }
+  
+  /**
+   * Sets a piece of data
+   *
+   * @param  string  $key    Name of variable
+   * @param  string  $value  Value of variable
+   *
+   * @return RendererInterface  Returns self for chaining
+   *
+   * @since  1.0
+   */
+  public function set($key, $value)
+  {
+    
+  }
+  
 }


### PR DESCRIPTION
Temporary work in progress class.
Throws Strict Standards error as Mustache native `render()` declaration is not compatible with interface.
Must be fixed later. 
