### PR TITLE
Reverse order of addFolder method arguments

### DIFF
--- a/src/MustacheRenderer.php
+++ b/src/MustacheRenderer.php
@@ -36,14 +36,14 @@ class MustacheRenderer extends AbstractRenderer implements RendererInterface
 	/**
 	 * Add a folder with alias to the renderer
 	 *
-	 * @param   string  $alias      The folder alias
 	 * @param   string  $directory  The folder path
+	 * @param   string  $alias      The folder alias
 	 *
 	 * @return  MustacheRenderer  Returns self for chaining
 	 *
 	 * @since   1.0
 	 */
-	public function addFolder($alias, $directory)
+	public function addFolder($directory, $alias)
 	{
 		return $this;
 	}

--- a/src/MustacheRenderer.php
+++ b/src/MustacheRenderer.php
@@ -43,7 +43,7 @@ class MustacheRenderer extends AbstractRenderer implements RendererInterface
 	 *
 	 * @since   1.0
 	 */
-	public function addFolder($directory, $alias)
+	public function addFolder($directory, $alias = null)
 	{
 		return $this;
 	}

--- a/src/PhpEngineRenderer.php
+++ b/src/PhpEngineRenderer.php
@@ -53,14 +53,14 @@ class PhpEngineRenderer extends AbstractRenderer implements RendererInterface
 	/**
 	 * Add a folder with alias to the renderer
 	 *
-	 * @param   string  $alias      The folder alias
 	 * @param   string  $directory  The folder path
+	 * @param   string  $alias      The folder alias
 	 *
 	 * @return  PhpEngineRenderer  Returns self for chaining
 	 *
 	 * @since   1.0
 	 */
-	public function addFolder($alias, $directory)
+	public function addFolder($directory, $alias)
 	{
 		// TODO: Implement addFolder() method.
 		return $this;

--- a/src/PhpEngineRenderer.php
+++ b/src/PhpEngineRenderer.php
@@ -60,7 +60,7 @@ class PhpEngineRenderer extends AbstractRenderer implements RendererInterface
 	 *
 	 * @since   1.0
 	 */
-	public function addFolder($directory, $alias)
+	public function addFolder($directory, $alias = null)
 	{
 		// TODO: Implement addFolder() method.
 		return $this;

--- a/src/PlatesRenderer.php
+++ b/src/PlatesRenderer.php
@@ -54,14 +54,14 @@ class PlatesRenderer extends AbstractRenderer implements RendererInterface
 	/**
 	 * Add a folder with alias to the renderer
 	 *
-	 * @param   string  $alias      The folder alias
 	 * @param   string  $directory  The folder path
+	 * @param   string  $alias      The folder alias
 	 *
 	 * @return  PlatesRenderer  Returns self for chaining
 	 *
 	 * @since   1.0
 	 */
-	public function addFolder($alias, $directory)
+	public function addFolder($directory, $alias)
 	{
 		$this->getRenderer()->addFolder($alias, $directory);
 

--- a/src/PlatesRenderer.php
+++ b/src/PlatesRenderer.php
@@ -60,9 +60,15 @@ class PlatesRenderer extends AbstractRenderer implements RendererInterface
 	 * @return  PlatesRenderer  Returns self for chaining
 	 *
 	 * @since   1.0
+	 * @throws  \InvalidArgumentException
 	 */
-	public function addFolder($directory, $alias)
+	public function addFolder($directory, $alias = null)
 	{
+		if ($alias === null)
+		{
+			throw new \InvalidArgumentException('Setting an alias is required in Plates');
+		}
+
 		$this->getRenderer()->addFolder($alias, $directory);
 
 		return $this;

--- a/src/RendererInterface.php
+++ b/src/RendererInterface.php
@@ -25,7 +25,7 @@ interface RendererInterface
 	 *
 	 * @since   1.0
 	 */
-	public function addFolder($directory, $alias);
+	public function addFolder($directory, $alias = null);
 
 	/**
 	 * Checks if folder, folder alias, template or template path exists

--- a/src/RendererInterface.php
+++ b/src/RendererInterface.php
@@ -18,14 +18,14 @@ interface RendererInterface
 	/**
 	 * Add a folder with alias to the renderer
 	 *
-	 * @param   string  $alias      The folder alias
 	 * @param   string  $directory  The folder path
+	 * @param   string  $alias      The folder alias
 	 *
 	 * @return  RendererInterface  Returns self for chaining
 	 *
 	 * @since   1.0
 	 */
-	public function addFolder($alias, $directory);
+	public function addFolder($directory, $alias);
 
 	/**
 	 * Checks if folder, folder alias, template or template path exists

--- a/src/TwigRenderer.php
+++ b/src/TwigRenderer.php
@@ -59,14 +59,14 @@ class TwigRenderer extends AbstractRenderer implements RendererInterface
 	/**
 	 * Add a folder with alias to the renderer
 	 *
-	 * @param   string  $alias      The folder alias
 	 * @param   string  $directory  The folder path
+	 * @param   string  $alias      The folder alias
 	 *
 	 * @return  TwigRenderer  Returns self for chaining
 	 *
 	 * @since   1.0
 	 */
-	public function addFolder($alias, $directory)
+	public function addFolder($directory, $alias)
 	{
 		$this->getRenderer()->getLoader()->addPath($directory, $alias);
 	}

--- a/src/TwigRenderer.php
+++ b/src/TwigRenderer.php
@@ -66,8 +66,13 @@ class TwigRenderer extends AbstractRenderer implements RendererInterface
 	 *
 	 * @since   1.0
 	 */
-	public function addFolder($directory, $alias)
+	public function addFolder($directory, $alias = null)
 	{
+		if ($alias === null)
+		{
+			$alias = \Twig_Loader_Filesystem::MAIN_NAMESPACE;
+		}
+
 		$this->getRenderer()->getLoader()->addPath($directory, $alias);
 	}
 


### PR DESCRIPTION
Directory is always required when adding a folder path. However the alias is only necessary in some implementations. This PR makes it an optional second PR. In plates where the alias is required we throw and invalid  argument exception if an alias isn't given. In twig we use the default parameter (the default namespace)