### PR TITLE
[3.x] Don't include development related files in distribution package

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,11 @@
+.github/ export-ignore
+.phan/ export-ignore
+docs/ export-ignore
+tests/ export-ignore
+.drone.jsonnet export-ignore
+.drone.yml export-ignore
+.editorconfig export-ignore
+.gitattributes export-ignore
+.gitignore export-ignore
+phpunit.xml.dist export-ignore
+ruleset.xml export-ignore


### PR DESCRIPTION
### Summary of Changes
- .gitattributes is updated to reflect changes
- development related files and directories excluded from distribution packages

### Testing Instructions
- Code review
- The files and directories listed in .gitattributes are not included in the zip package
